### PR TITLE
fix para ruby 1.9

### DIFF
--- a/lib/acts_as_unvlogable.rb
+++ b/lib/acts_as_unvlogable.rb
@@ -8,9 +8,8 @@ if defined?(ActiveSupport).nil?
 end
 require 'acts_as_unvlogable/string_extend'
 
-RAILS_ROOT='.' if !defined? RAILS_ROOT
 # Video classes
-videolibs = File.join(RAILS_ROOT, "**", "acts_as_unvlogable", "vg_*.rb")
+videolibs = File.join(File.dirname(__FILE__), "acts_as_unvlogable", "vg_*.rb")
 Dir.glob(videolibs).each {|file| require file}
 
 class UnvlogIt

--- a/lib/acts_as_unvlogable/string_extend.rb
+++ b/lib/acts_as_unvlogable/string_extend.rb
@@ -3,6 +3,6 @@ class String
   def query_param(param_name)
     raise ArgumentError.new("param name can't be nil") if param_name.blank?
     uri = URI.parse(self)
-    (CGI::parse(uri.query)[param_name].to_s if uri.query) || nil
+    (CGI::parse(uri.query)[param_name].first.to_s if uri.query) || nil
   end
 end


### PR DESCRIPTION
Buenas,
a la hora de añadir un vídeo de youtube utilizando ruby 1.9.2 me estaba dando problemas ya que parece que ahora CGI::parse(uri.query)[param_name] devolvía un array en lugar de una cadena y al llamar al método to_s me devolvía el id en plan ["KQPG7rgFK6w"] y fallaba al tratar de añadir un vídeo de youtube por ejemplo.
también quité la llamada a RAILS_ROOT para que funcione con Rails 3

muchas gracias por el plugin, me solucionó la papeleta :)
