### PR TITLE
Corrected error with youtube-g and ruby 1.9.2

### DIFF
--- a/lib/acts_as_unvlogable.rb
+++ b/lib/acts_as_unvlogable.rb
@@ -1,5 +1,5 @@
 # Included gems
-require 'youtube_g'
+require 'youtube_it'
 require 'acts_as_unvlogable/flickr'
 # Extensions
 if defined?(ActiveSupport).nil?

--- a/lib/acts_as_unvlogable/vg_vimeo.rb
+++ b/lib/acts_as_unvlogable/vg_vimeo.rb
@@ -1,6 +1,6 @@
 # ----------------------------------------------
-#  Class for Youtube (youtube.com)
-#  http://www.youtube.com/watch?v=25AsfkriHQc
+#  Class for Vimeo (vimeo.com)
+#  http://vimeo.com/5362441
 # ----------------------------------------------
 
 

--- a/lib/acts_as_unvlogable/vg_youtube.rb
+++ b/lib/acts_as_unvlogable/vg_youtube.rb
@@ -7,7 +7,7 @@
 class VgYoutube
   
   def initialize(url=nil, options={})
-    object = YouTubeG::Client.new rescue {}
+    object = YouTubeIt::Client.new rescue {}
     @url = url
     @video_id = @url.query_param('v')
     @details = object.video_by(@video_id)


### PR DESCRIPTION
youtube-g returns an error with ruby 1.9.2 

https://github.com/tmm1/youtube-g/issues#issue/7

So I have modified it to use youtube_it, a fork of youtube-g (as suggested in the comments of the issue),  that seems to be maintained and updated (last commit in youtube-g was in 2009)
